### PR TITLE
converters/html/converter.py: make use of the ijson package to signif…

### DIFF
--- a/converters/html/converter.py
+++ b/converters/html/converter.py
@@ -8,6 +8,7 @@ import logging
 import datetime
 from pathlib import Path
 import json
+import ijson
 import xml.etree.ElementTree as ET
 
 
@@ -15,11 +16,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Converter:
-    def import_data(self, path):
-        with open(path, encoding='utf-8') as fd:
-            self.jfile = json.load(fd)
 
-    def convert(self, outpath):
+    def convert(self, inpath, outpath):
         seen = set()
 
         def convert_conversation(conversation):
@@ -48,7 +46,7 @@ class Converter:
 
             LOGGER.info('done conversation %r', addr)
 
-        for conversation in self.jfile['conversations']:
+        for conversation in ijson.items( open(inpath), 'conversations.item' ):
             try:
                 convert_conversation(conversation)
             except Exception as exc:
@@ -163,9 +161,9 @@ def main():
     )
 
     c = Converter()
-    c.import_data(args.file)
-    c.convert(args.output_dir)
+    c.convert(args.file, args.output_dir)
 
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
…icantly reduce memory usage.

I had a problem using this converter gobbling up all 16GB of my ram and crashing before writing a single file. Switching from the json package to ijson allowed each conversation thread to be processed one at a time, and solved the problem handily. 